### PR TITLE
Set traefik as a default network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - ./traefik.toml:/etc/traefik/traefik.toml
       - ./traefik/:/traefik/
       - ssl:/ssl
-    networks:
-      - traefik
   dnsmasq:
     image: andyshinn/dnsmasq
     ports:
@@ -40,5 +38,5 @@ services:
 volumes:
   ssl:
 networks:
-  traefik:
+  default:
     name: ${EXTERNAL_NETWORK:-ridi}


### PR DESCRIPTION
`docker-compose up` create two networks, default and ridi.
This commit sets ridi as a default, so not to create meanless one.